### PR TITLE
Fix compilation with latest VS2019

### DIFF
--- a/WinSparkle-2019.vcxproj
+++ b/WinSparkle-2019.vcxproj
@@ -25,7 +25,7 @@
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>WinSparkle</RootNamespace>
     <ProjectName>WinSparkle</ProjectName>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
Windows SDK 8.1 is deprecated and doesn't build correctly, see
https://developercommunity.visualstudio.com/content/problem/1139955/c-bu
ilds-with-windows-sdk-81-fail-after-upgrade-to.html

Fix by using Windows 10 SDK; this does not affect ability to ship to
older Windows versions.